### PR TITLE
fix: support RN 0.70+

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-WebBrowser_kotlinVersion=1.3.50
+WebBrowser_kotlinVersion=1.6.0
 WebBrowser_compileSdkVersion=29
 WebBrowser_targetSdkVersion=29

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { AppState, AppStateStatus, Linking, Platform } from 'react-native';
+import { AppState, AppStateStatus, Linking, Platform, EmitterSubscription } from 'react-native';
 import NativeWebBrowser from './NativeWebBrowser';
 import {
   RedirectEvent,
@@ -356,6 +356,9 @@ function _onAppStateChangeAndroid(state: AppStateStatus) {
   }
 }
 
+// Event Emitter of react native `Linking`
+let _linkingSubscription: EmitterSubscription;
+
 async function _openBrowserAndWaitAndroidAsync(
   startUrl: string,
   browserParams: WebBrowserOpenOptions = {}
@@ -436,7 +439,7 @@ function _stopWaitingForRedirect() {
     );
   }
 
-  Linking.removeEventListener('url', _redirectHandler);
+  _linkingSubscription?.remove?.();
   _redirectHandler = null;
 }
 
@@ -450,6 +453,6 @@ function _waitForRedirectAsync(
       }
     };
 
-    Linking.addEventListener('url', _redirectHandler);
+    _linkingSubscription = Linking.addEventListener('url', _redirectHandler);
   });
 }


### PR DESCRIPTION
In React native 0.70+:
- required Kotlin `1.6.0` to run.
- deprecated `removeEventListener` will throw error.